### PR TITLE
update 3

### DIFF
--- a/materials/hud/leaderboard_class_wheelofdoom_whammy.vmt
+++ b/materials/hud/leaderboard_class_wheelofdoom_whammy.vmt
@@ -1,6 +1,6 @@
 "UnlitGeneric"
 {
-	"$baseTexture" "hud/leaderboard_class_wheelofdoom_whammy"
+	"$baseTexture" "hud\leaderboard_class_wheelofdoom_whammy"
 	"$vertexcolor" 1
 	"$no_fullbright" 1
 	"$ignorez" 1

--- a/scripts/population/mvm_condemned_b3_exp_trespasser.pop
+++ b/scripts/population/mvm_condemned_b3_exp_trespasser.pop
@@ -1,6 +1,6 @@
 #base robot_giant.pop
 #base robot_standard.pop
-//Trespasser - Zombie Survival - V3
+//Trespasser - Zombie Survival - V4
 //Made By Hell-met http://steamcommunity.com/id/hell-met/
 //Entwork help By washy https://steamcommunity.com/id/gg2washy/
 //Big entwork help By Jurrell https://steamcommunity.com/profiles/76561198145026974/
@@ -381,10 +381,6 @@ WaveSchedule
 		"min respawn time" 9999
 		"always allow taunt" 1
 		"crit mod disabled" 0
-		Soldier
-		{
-			"increase buff duration" 0.75				//all banners start with -25% duration
-		}
 		Engineer
 		{
 			"mvm sentry ammo" 0.5						//experimental sentry
@@ -649,11 +645,11 @@ WaveSchedule
 	//	"minicrits become crits" 1
 	//}
 
-	//ItemAttributes [$SIGSEGV]
-	//{
-	//	ItemName "The Gunslinger"
-	//	"move speed penalty" 0.85
-	//}
+	ItemAttributes [$SIGSEGV]
+	{
+		ItemName "The Gunslinger"
+		"move speed penalty" 0.85
+	}
 
 	ItemAttributes [$SIGSEGV]
 	{
@@ -928,7 +924,7 @@ WaveSchedule
 		OriginalItemName "TF_WEAPON_BAT"
 		"is_a_sword" 1
 		"fire rate bonus" 1.6
-		"damage bonus" 1.85
+		"damage bonus" 1.857
 		"custom kill icon" "nessieclub"
 		"custom hit sound" "weapons\bat_baseball_hit_world2.wav"
 		"custom item model" "models/workshop/weapons/c_models/c_golfclub/c_golfclub.mdl"
@@ -1012,7 +1008,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1
 			Item "Zombie Scout"
 			Item "Basic Spellbook"
@@ -1065,7 +1061,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Soldier"
 			Item "Basic Spellbook"
@@ -1118,7 +1114,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Pyro"
 			Item "Basic Spellbook"
@@ -1176,7 +1172,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Demo"
 			Item "Basic Spellbook"
@@ -1228,7 +1224,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Heavy"
 			Item "Basic Spellbook"
@@ -1278,7 +1274,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Engineer"
 			Item "Basic Spellbook"
@@ -1335,7 +1331,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Medic"
 			Item "Basic Spellbook"
@@ -1395,7 +1391,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "Basic Spellbook"
@@ -1451,7 +1447,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Spy"
 			Item "Basic Spellbook"
@@ -1507,7 +1503,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1
 			Item "Zombie Scout"
 			Item "Basic Spellbook"
@@ -1569,7 +1565,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Soldier"
 			Item "Basic Spellbook"
@@ -1631,7 +1627,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Pyro"
 			Item "Basic Spellbook"
@@ -1699,7 +1695,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Demo"
 			Item "Basic Spellbook"
@@ -1763,7 +1759,7 @@ WaveSchedule
 			MaxVisionRange 750
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Attributes HoldFireUntilFullReload
 			Item "Zombie Demo"
 			Item "Breach and Bomb"
@@ -1775,7 +1771,7 @@ WaveSchedule
 			{
 				ItemName "TF_WEAPON_GRENADELAUNCHER"
 				"fire rate penalty" 2
-				//"grenade explode on impact" 1
+				"grenade explode on impact" 1
 				"no self blast dmg" 2
 			}
 			CharacterAttributes
@@ -1810,7 +1806,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Heavy"
 			Item "Basic Spellbook"
@@ -1871,7 +1867,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			DropWeapon 1
 			MaxVisionRange 750
 			Item "Zombie Heavy"
@@ -1913,7 +1909,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Engineer"
 			Item "Basic Spellbook"
@@ -1980,7 +1976,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Medic"
 			Item "Basic Spellbook"
@@ -2043,7 +2039,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "Basic Spellbook"
@@ -2109,7 +2105,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Spy"
 			Item "Basic Spellbook"
@@ -2175,7 +2171,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Scout"
 			Item "Basic Spellbook"
@@ -2229,7 +2225,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Scout"
 			Item "Basic Spellbook"
@@ -2283,7 +2279,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Soldier"
 			Item "Basic Spellbook"
@@ -2338,7 +2334,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Soldier"
 			Item "Basic Spellbook"
@@ -2392,7 +2388,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Pyro"
 			Item "Basic Spellbook"
@@ -2451,7 +2447,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Pyro"
 			Item "Basic Spellbook"
@@ -2510,7 +2506,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Demo"
 			Item "Basic Spellbook"
@@ -2563,7 +2559,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Demo"
 			Item "Basic Spellbook"
@@ -2617,7 +2613,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Heavy"
 			Item "Basic Spellbook"
@@ -2670,7 +2666,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Heavy"
 			Item "Basic Spellbook"
@@ -2723,7 +2719,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Engineer"
 			Item "Basic Spellbook"
@@ -2781,7 +2777,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Engineer"
 			Item "Basic Spellbook"
@@ -2839,7 +2835,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Medic"
 			Item "Basic Spellbook"
@@ -2886,7 +2882,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Medic"
 			Item "Basic Spellbook"
@@ -2940,7 +2936,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "Basic Spellbook"
@@ -2997,7 +2993,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "Basic Spellbook"
@@ -3054,7 +3050,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Spy"
 			Item "Basic Spellbook"
@@ -3110,7 +3106,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Spy"
 			Item "Basic Spellbook"
@@ -3166,7 +3162,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "Basic Spellbook"
@@ -3243,7 +3239,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Sniper"
 			Item "The Bat Outta Hell"
@@ -3343,7 +3339,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "The Backburner"
 			Item "Basic Spellbook"
@@ -3446,7 +3442,7 @@ WaveSchedule
 			Attributes UseBossHealthBar
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Item "The Bat Outta Hell"
 			UseMeleeThreatPrioritization 1
 			WeaponRestrictions MeleeOnly
@@ -3576,7 +3572,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "The Bolshevik Biker"
 			//Item "Zombie Heavy"
@@ -3653,7 +3649,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "The Bolshevik Biker"
 			//Item "Zombie Heavy"
@@ -3730,7 +3726,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "The Bolshevik Biker"
 			//Item "Zombie Heavy"
@@ -3810,7 +3806,7 @@ WaveSchedule
 			Attributes MiniBoss
 			Attributes DisableDodge
 			WeaponRestrictions MeleeOnly
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			CustomEyeParticle "killstreak_t6_lvl2" [$SIGSEGV]
 			CustomEyeGlowColor "255 255 255" [$SIGSEGV]
 			UseCustomModel models/bots/heavy/bot_heavy_gibby.mdl [$SIGSEGV]
@@ -3943,7 +3939,7 @@ WaveSchedule
 			Attributes MiniBoss
 			Attributes DisableDodge
 			WeaponRestrictions MeleeOnly
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			CustomEyeParticle "killstreak_t6_lvl2" [$SIGSEGV]
 			CustomEyeGlowColor "255 255 255" [$SIGSEGV]
 			UseCustomModel models/bots/heavy/bot_heavy_gibby.mdl [$SIGSEGV]
@@ -4075,7 +4071,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes MiniBoss
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			Item "Zombie Scout"
 			Item "Baseball Bill's Sports Shine"
@@ -4131,7 +4127,7 @@ WaveSchedule
 			{
 				"dmg pierces resists absorbs" 1
 				"move speed bonus" 0.5
-				"stomp player damage" 15
+				"stomp player damage" 12
 				"stomp building damage" 1337
 				"stomp player force" 100
 				"stomp player time" 0.1
@@ -4156,7 +4152,7 @@ WaveSchedule
 
 		Zombie_Skeleton1
 		{
-			Class Sniper
+			Class Pyro
 			Classicon dead_blu_lite
 			Name "Skeleton"
 			UseCustomModel models/bots/skeleton_sniper/skeleton_sniper.mdl [$SIGSEGV]
@@ -4177,7 +4173,7 @@ WaveSchedule
 			StripItemSlot 1
 			ItemAttributes
 			{
-				ItemName "TF_WEAPON_CLUB"
+				ItemName "TF_WEAPON_FIREAXE"
 				"is invisible" 1
 				"custom kill icon" "skull_tf"
 				"dmg taken from bullets increased" 0.5
@@ -4214,7 +4210,7 @@ WaveSchedule
 
 		Zombie_Skeleton2
 		{
-			Class Sniper
+			Class Pyro
 			Classicon dead_blu_lite
 			Name "Skeleton"
 			UseCustomModel models/bots/skeleton_sniper/skeleton_sniper.mdl [$SIGSEGV]
@@ -4234,7 +4230,7 @@ WaveSchedule
 			StripItemSlot 1
 			ItemAttributes
 			{
-				ItemName "TF_WEAPON_CLUB"
+				ItemName "TF_WEAPON_FIREAXE"
 				"is invisible" 1
 				"custom kill icon" "skull_tf"
 				"dmg taken from bullets increased" 0.5
@@ -4276,7 +4272,7 @@ WaveSchedule
 
 		Zombie_Skeleton3
 		{
-			Class Sniper
+			Class Pyro
 			Classicon dead_blu_lite
 			Name "Skeleton"
 			UseCustomModel models/bots/skeleton_sniper/skeleton_sniper.mdl [$SIGSEGV]
@@ -4297,7 +4293,7 @@ WaveSchedule
 			StripItemSlot 1
 			ItemAttributes
 			{
-				ItemName "TF_WEAPON_CLUB"
+				ItemName "TF_WEAPON_FIREAXE"
 				"is invisible" 1
 				"custom kill icon" "skull_tf"
 				"dmg taken from bullets increased" 0.5
@@ -4751,7 +4747,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes Miniboss
 			Scale 1
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Skill Normal
 			DropWeapon 1
 			Skin 4
@@ -4788,7 +4784,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes Miniboss
 			Scale 1
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Skill Normal
 			DropWeapon 1
 			Skin 4
@@ -4823,7 +4819,7 @@ WaveSchedule
 			NoIdleSound 1
 			Attributes Miniboss
 			Scale 1
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Skill Normal
 			DropWeapon 1
 			Skin 4
@@ -4867,7 +4863,7 @@ WaveSchedule
 			Attributes Miniboss
 			Attributes DisableDodge
 			Scale 1
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Skill Normal
 			DropWeapon 1
 			Skin 4
@@ -4911,7 +4907,7 @@ WaveSchedule
 			Health 200
 			Skill Expert
 			Action Mobber
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			NoBombUpgrades 1
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			UseCustomModel models/bots/soldier/bot_soldier_gibby.mdl [$SIGSEGV]
@@ -4950,7 +4946,7 @@ WaveSchedule
 			Name "Corrupted"
 			Health 65
 			Skill Expert
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Attributes DisableDodge
 			Attributes IgnoreEnemies
 			Attributes SuppressFire
@@ -4996,7 +4992,7 @@ WaveSchedule
 			Action Mobber
 			RocketJump 1
 			FastUpdate 1
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			NoBombUpgrades 1
 			AimTrackingInterval 0
 			Attributes DisableDodge
@@ -5039,7 +5035,7 @@ WaveSchedule
 			MaxVisionRange 500
 			Health 175
 			Skill Normal
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Action Mobber
 			Item "The Gilded Guard"
 			DropWeapon 1
@@ -5063,7 +5059,7 @@ WaveSchedule
 			MaxVisionRange 500
 			Action Mobber
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			CustomEyeGlowColor "255 0 0" [$SIGSEGV]
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			UseCustomModel models/bots/heavy/bot_heavy_gibby.mdl [$SIGSEGV]
@@ -5087,7 +5083,7 @@ WaveSchedule
 			Skill Normal
 			MaxVisionRange 500
 			Attributes DisableDodge
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Item "Dillinger's Duffel"
 			CustomEyeGlowColor "0 255 0" [$SIGSEGV]
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
@@ -5144,7 +5140,7 @@ WaveSchedule
 			Health 150
 			Skill Expert
 			Scale 1.0025
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Attributes DisableDodge
 			Attributes SpawnWithFullCharge
 			CustomEyeGlowColor "255 0 0" [$SIGSEGV]
@@ -5188,7 +5184,7 @@ WaveSchedule
 			Attributes HoldFireUntilFullReload
 			NoBombUpgrades 1
 			Action Mobber
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			AimLeadProjectileSpeed 1100 [$SIGSEGV] 
 			UseMeleeThreatPrioritization 1 [$SIGSEGV]
 			UseCustomModel models/bots/soldier_boss/bot_soldier_boss_gibby.mdl [$SIGSEGV]
@@ -5221,7 +5217,7 @@ WaveSchedule
 			Attributes HoldFireUntilFullReload
 			NoBombUpgrades 1
 			Action Mobber
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			Item "The Direct Hit"
 			AimLeadProjectileSpeed 1980 [$SIGSEGV] 
 			UseCustomModel models/bots/soldier_boss/bot_soldier_boss_gibby.mdl [$SIGSEGV]
@@ -5257,7 +5253,7 @@ WaveSchedule
 			Attributes UseBossHealthBar
 			NoBombUpgrades 1
 			Action Mobber
-			//ExtAttr IgnoreBuildings
+			ExtAttr IgnoreBuildings
 			AimLeadProjectileSpeed 0 [$SIGSEGV]
 			AimAt Head [$SIGSEGV]
 			UseCustomModel models/bots/soldier_boss/bot_soldier_boss_gibby.mdl [$SIGSEGV]
@@ -5855,6 +5851,16 @@ WaveSchedule
             }
 		}
 
+		sentry_collision_template
+        {
+            NoFixup 1
+            logic_timer
+            {
+                "refiretime" "3"
+                "ontimer" "obj_sentrygun,$SetProp$m_CollisionGroup,3,0,-1"
+            }
+        }
+
 		p_skullhead
 		{
 			NoFixup 1
@@ -6338,8 +6344,8 @@ WaveSchedule
             trigger_teleport
             {
                 "targetname" "leap_tele"
-                "mins" "-134.5 -1 -74"
-                "maxs" "134.5 1 74"
+                "mins" "-134.5 -1 -274"
+                "maxs" "134.5 1 274"
                 "origin" "231 1279 291"
                 "spawnflags" "1"
                 "filtername" "filter_leaper"
@@ -7213,7 +7219,7 @@ WaveSchedule
 				"disableshadows" "1"
 				"modelscale" "1"
 				"SetBodyGroup" "0"
-				"skin" "1"
+				"skin" "0"
 				"solid" "6"
 				"spawnflags" "0"
 			}
@@ -7615,6 +7621,33 @@ WaveSchedule
 				"skin" "0"
 				"solid" "6"
 				"spawnflags" "0"
+			}
+		}
+
+		p_barrel
+		{
+			NoFixup 1
+			prop_dynamic
+			{
+				"classname" "prop_dynamic"
+				"model" "models\props_medical\beer_barrels.mdl"
+				"disableshadows" "1"
+				"modelscale" "1"
+				"SetBodyGroup" "0"
+				"skin" "0"
+				"solid" "6"
+				"spawnflags" "0"
+			}
+		}
+
+		p_beer
+		{
+			NoFixup 1
+			func_wall
+			{
+				"origin" "700 280 456"
+				"mins" "-85.35 -113 -224"
+				"maxs" "85.35 113 224"
 			}
 		}
 
@@ -9772,6 +9805,11 @@ WaveSchedule
 
 	SpawnTemplate [$SIGSEGV]
 	{
+		Name	"sentry_collision_template"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
 		Name	"p_pusher"
 	}
 
@@ -10167,6 +10205,25 @@ WaveSchedule
 	SpawnTemplate [$SIGSEGV]
 	{
 		Name   "p_teleporterfinale"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
+		Name "p_beer"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
+		Name   "p_barrel"
+		Origin "647 375 189"
+		Angles "0 180 0"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
+		Name   "p_barrel"
+		Origin "660 375 189"
+		Angles "0 -180 0"
 	}
 
 	SpawnTemplate [$SIGSEGV]
@@ -13585,10 +13642,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13601,10 +13654,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13615,10 +13664,6 @@ WaveSchedule
 					Name "Atomic Skeleton"
 					Skin 2
 					Health 250
-					AddCond [$SIGSEGV]
-					{
-						Name TF_COND_SPEED_BOOST
-					}
 					AddCond [$SIGSEGV]
 					{
 						Name TF_COND_OFFENSEBUFF
@@ -13650,10 +13695,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13666,10 +13707,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13680,10 +13717,6 @@ WaveSchedule
 					Name "Atomic Skeleton"
 					Skin 2
 					Health 250
-					AddCond [$SIGSEGV]
-					{
-						Name TF_COND_SPEED_BOOST
-					}
 					AddCond [$SIGSEGV]
 					{
 						Name TF_COND_OFFENSEBUFF
@@ -13717,10 +13750,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13733,10 +13762,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13747,10 +13772,6 @@ WaveSchedule
 					Name "Atomic Skeleton"
 					Skin 2
 					Health 250
-					AddCond [$SIGSEGV]
-					{
-						Name TF_COND_SPEED_BOOST
-					}
 					AddCond [$SIGSEGV]
 					{
 						Name TF_COND_OFFENSEBUFF
@@ -13784,10 +13805,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13800,10 +13817,6 @@ WaveSchedule
 					Health 250
 					AddCond [$SIGSEGV]
 					{
-						Name TF_COND_SPEED_BOOST
-					}
-					AddCond [$SIGSEGV]
-					{
 						Name TF_COND_OFFENSEBUFF
 					}
 				}
@@ -13814,10 +13827,6 @@ WaveSchedule
 					Name "Atomic Skeleton"
 					Skin 2
 					Health 250
-					AddCond [$SIGSEGV]
-					{
-						Name TF_COND_SPEED_BOOST
-					}
 					AddCond [$SIGSEGV]
 					{
 						Name TF_COND_OFFENSEBUFF
@@ -17628,7 +17637,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17645,7 +17654,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17662,7 +17671,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17679,7 +17688,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17696,7 +17705,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17713,7 +17722,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 
@@ -17730,7 +17739,7 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-					"dmg penalty vs players" 1.4
+					"dmg penalty vs players" 2
 				}
 			}
 


### PR DESCRIPTION
- Condemned - Trespasser
	- General
		- Regular sentry gun can no longer block opponents
		- All enemies ignore engineer buildables (again)
		- Possibly fixed a problem where survivors gave more money than intended
		
	- Weapons
		- Added -15% move speed penalty to Gunslinger
		- Removed Banner duration penalty
		- Fixed bad Bludgeoner damage rounding
		 
	- Zombies
		- Removed Atomic Skeleton speed boost
		- Decreased Leaper damage from 15 to 12
		- Increased Possessed damage from 35 to 50
		- Riot GL pipes now explode on impact

- Decay - Skull Scamper
	- Fixed a bug that made various projectiles get stuck on the information booth

- Null - Void Voyage
	- Wave 5
		- Fixed bug that often resulted in Bouncealot's Revenge spawning in the wrong location
	- Wave 6
		- Reduced reliance on brush entities in the finale of Phase 5.
		- Sentry Busters can no longer spawn during Phase 5.
	