### PR TITLE
update 4

### DIFF
--- a/scripts/population/mvm_condemned_b3_exp_trespasser.pop
+++ b/scripts/population/mvm_condemned_b3_exp_trespasser.pop
@@ -277,15 +277,15 @@ WaveSchedule
 
 	ClassLimit [$SIGSEGV]
     {
-		Scout		2
-		Soldier		2
-		Pyro		2
-		Demoman		2
-        Heavy		2
-        Engineer	2
-		Medic		2
-        Sniper		2
-        Spy			2
+		Scout		 2
+		Soldier		 2
+		Pyro		 2
+		Demoman		 2
+        HeavyWeapons 2
+        Engineer	 2
+		Medic		 2
+        Sniper		 2
+        Spy			 2
     }
 
 	OverrideSounds [$SIGSEGV]
@@ -609,6 +609,12 @@ WaveSchedule
 		"blast dmg to self increased" 0.48
 		"self dmg push force decreased" 0.25
 		"regenerate stickbomb" 1
+	}
+
+	ItemAttributes [$SIGSEGV]
+	{
+		ClassName "tf_weapon_lunchbox"
+		"gesture speed increase" 1.75
 	}
 
 	ItemAttributes [$SIGSEGV]
@@ -10224,6 +10230,20 @@ WaveSchedule
 		Name   "p_barrel"
 		Origin "660 375 189"
 		Angles "0 -180 0"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
+		Name   "p_cashsave"
+		Origin "647 375 189"
+		Angles "0 180 0"
+	}
+
+	SpawnTemplate [$SIGSEGV]
+	{
+		Name   "p_cashsave"
+		Origin "660 375 189"
+		Angles "0 180 0"
 	}
 
 	SpawnTemplate [$SIGSEGV]

--- a/scripts/population/mvm_creepside_b2_adv_dismal_devilry.pop
+++ b/scripts/population/mvm_creepside_b2_adv_dismal_devilry.pop
@@ -1699,7 +1699,7 @@ WaveSchedule
             { 
                 Class Pyro
                 ClassIcon gry_lite
-                Skill Hard
+                Skill Normal
                 Health 650
                 Scale 1.35
                 StripItemSlot 2
@@ -1720,6 +1720,7 @@ WaveSchedule
                 {
                     "collect currency on kill" 1
                     "head scale" 0.8
+                    "move speed bonus" 0.75
                     "crit mod disabled" 0
                     "dmg taken mult from special damage type 2" 2.5
                 }
@@ -2147,16 +2148,16 @@ WaveSchedule
                         Spell [$SIGSEGV]
 			            {
 			            	Type     "Pumpkin MIRV"
-			            	Delay    7.05
-			            	Cooldown 14.1
+			            	Delay    11.35
+			            	Cooldown 23.6
 			            	Charges  1
 			            	Limit    1
 			            }	
                         Spell [$SIGSEGV]
 			            {
 			            	Type     "Summon Monoculus"
-			            	Delay    14.1
-			            	Cooldown 14.1
+			            	Delay    23.1
+			            	Cooldown 23.6
 			            	Charges  1
 			            	Limit    1
 			            }
@@ -3384,6 +3385,11 @@ WaveSchedule
                     "damage penalty" 0.4
                     "spread penalty" 1.35
                 }
+                CharacterAttributes
+                {
+                    "collect currency on kill" 1
+                    "health from healers reduced" .1
+                }
 				Skill Expert
 				Action Mobber
 				AddCond { Name TF_COND_REPROGRAMMED }
@@ -3924,9 +3930,9 @@ WaveSchedule
             Name "w6_c"
             WaitForAllDead "w6_b"
             Where spawnbot
-            TotalCount 12
-            MaxActive 12
-            SpawnCount 4
+            TotalCount 9
+            MaxActive 9
+            SpawnCount 3
             WaitBeforeStarting 0
             WaitBetweenSpawns 12
         
@@ -3944,17 +3950,6 @@ WaveSchedule
                     UseHumanModel 2
 			        Item "Zombie Heavy"
                     SpawnTemplate "powerup_logic"
-                }
-                TFBot
-                {
-                    Template T_TFBot_Medic_Resistance
-                    CharacterAttributes
-			        {
-                        "voice pitch scale" 0.8
-			        }
-                    UseHumanModel 2
-			        Item "Zombie Medic"
-                    SpawnTemplate "powerup_logic_medic"
                 }
                 TFBot
                 {
@@ -5766,6 +5761,7 @@ WaveSchedule
             CharacterAttributes
             {
                 "collect currency on kill" 1
+                "health from healers reduced" .1
             }
             SpawnTemplate "redbot_init"
             UseHumanModel 2
@@ -9630,10 +9626,10 @@ WaveSchedule
 				
 				// Changing how much is added each timer iteration changes the smoothness of the color transition
 				// (5 is smoother than 25, and goes through more colors values, but is also much slower)
-				"OnCase01"   "spelltank_color_bo,Add,2,0,-1"
+				"OnCase01"   "spelltank_color_bo,Add,1.1,0,-1"
                 "OnCase02"   "spelltank_color_ow,Add,18,0,-1"
 				"OnCase03"   "spelltank_color_owb,Add,18,0,-1"
-                "OnCase04"   "spelltank_color_bp,Add,2,0,-1"
+                "OnCase04"   "spelltank_color_bp,Add,1.1,0,-1"
                 "OnCase05"   "spelltank_color_pw,Add,18,0,-1"
                 "OnCase06"   "spelltank_color_pwb,Add,18,0,-1"
 			}

--- a/scripts/population/mvm_nightsky_rc4d_adv_nightsky_nightmare.pop
+++ b/scripts/population/mvm_nightsky_rc4d_adv_nightsky_nightmare.pop
@@ -20,6 +20,14 @@
 //- Ditto (maybe no 2nd set of fan spawns?)
 //- Reduce Giant Uber duration to 6, health threshold to...1200?
 
+//Changelog 31-10 (spooky)
+//- Added changes to Vita-saw, Huntsman, Spy-cicle
+//- Wave 2, wave 5: Added Hype condition to Homing Flare Rains, indicating their homing ability
+//- Wave 5: Added 12 Killer Bee Scouts to the first subwave.
+//- Wave 6 support's cash moved to teletank's cash to prevent potentially missed money from the support not spawning.
+//- Fixed both wave 6 tanks not deploying the bomb.
+//- Added a forcefield around the scaffolds on the left route, to prevent giants from getting stuck.
+
 //Themed waves:
 //- Nautical Nightmares (FireWeapon)
 //- Demonic Demolition
@@ -113,6 +121,15 @@ popuwashyon
 	PrecacheModel "models/bots/boss_bot/boss_blimp_damage_explode.mdl" [$SIGSEGV]
 	PrecacheModel "models/bots/boss_bot/boss_blimp_explode.mdl" [$SIGSEGV]
 	PrecacheModel "models/props_mvm/robot_spawnpoint.mdl" [$SIGSEGV]
+	
+	//mmmmm nah
+	// ItemBlacklist  [$SIGSEGV]
+	// {
+		// Name "Kritz Or Treat Canteen"
+		// Name "Default Power Up Canteen (MvM)"
+		// Name "Power Up Canteen (MvM)"
+		// Name "Battery Canteens"
+	// }
 	
 	ExtraSpawnPoint [$SIGSEGV]
 	{
@@ -335,6 +352,39 @@ popuwashyon
         }
 		
 		////////////////////////////////////////////////////////////////////////////
+		
+		GetOffMe
+		{
+			// func_nav_avoid
+			// {
+				// "tags" "giant"
+				// "start_disabled" "0"
+				// "team" "-2"
+				// "maxs" "180 178 103"
+				// "mins" "-180 -178 -103"
+				// "origin" "-4077 -3902 337"
+			// }
+			NoFixup 1
+            trigger_push
+            {
+                "alternateticksfix" "0"
+                "filtername" "filter_giants"
+				"maxs" "105 158 102"
+				"mins" "-105 -158 -102"
+				"origin" "-4090 -3882 337"
+                "pushdir" "0 15 0"
+                "spawnflags" "64"
+                "speed" "75"
+                "startdisabled" "0"
+            }
+			filter_tf_bot_has_tag
+			{
+				"Negated" "0"
+				"require_all_tags" "1"
+				"tags" "giant"
+				"targetname" "filter_giants"
+			}
+		}
 		
 		Vortex
 		{
@@ -720,16 +770,148 @@ popuwashyon
             }
         }
 		
+		//Vita-saw change
+		//ty @ Jurrell for making the base form of this. Quite neat!
+		//For those unfamiliar (me):
+		//- when Vita-saw is equipped, spawn this entire template
+		//- on spawn, add condition 130 and remove the machinery beam attrib from secondary slot
+		//- then, trigger a logic relay, which activates a filter
+		//- filter checks for cond 130, then adds the attrib with value 2.5 to slot 2
+        vsaw_equipped
+        {
+            OnSpawnOutput
+	    	{
+	    		Target "vsaw_checker"
+	    		Action "Trigger"
+	    		Delay 0.1
+	    	}
+            OnSpawnOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "medic machinery beam|1" //15 hp/sec
+	    		Delay 0.1
+	    	}
+            OnParentKilledOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "medic machinery beam|1" //15 hp/sec
+	    		Delay 0.1
+	    	}
+            OnSpawnOutput
+            {
+                Target "!activator"
+	        	Action "$AddCond"
+                Param "130"
+            }
+			filter_tf_condition
+			{
+				"targetname" "filter_has_vsaw"
+				"Negated" "0"
+				"condition" "130"
+				"OnPass" "!activator,$AddItemAttribute,medic machinery beam|2.5|1,0.1,-1"
+				"OnFail" "!activator,$AddItemAttribute,medic machinery beam|2.5|1,0.1,-1"
+			}
+            logic_relay 
+            {
+				"targetname" "vsaw_checker"
+				"OnTrigger" "filter_has_vsaw,TestActivator,!activator,0,-1"
+            }
+        }
+		
+		//The Spy-cicle tweak
+		//Gun spy REAL?
+		ice_equipped
+        {
+            OnSpawnOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "bullets per shot bonus|0"
+	    		Delay 0.1
+	    	}
+            OnSpawnOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "damage bonus HIDDEN|0"
+	    		Delay 0.1
+	    	}
+            OnSpawnOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "spread penalty|0"
+	    		Delay 0.1
+	    	}
+			
+            OnParentKilledOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "bullets per shot bonus|0"
+	    		Delay 0.1
+	    	}
+            OnParentKilledOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "damage bonus HIDDEN|0"
+	    		Delay 0.1
+	    	}
+            OnParentKilledOutput
+	    	{
+	    		Target "!activator"
+	    		Action "$RemoveItemAttribute"
+                Param "spread penalty|0"
+	    		Delay 0.1
+	    	}
+			
+            OnSpawnOutput
+	    	{
+	    		Target "ice_checker"
+	    		Action "Trigger"
+	    		Delay 0.1
+	    	}
+            OnSpawnOutput
+            {
+                Target "!activator"
+	        	Action "$AddCond"
+                Param "130"
+            }
+			filter_tf_condition
+			{
+				"targetname" "filter_has_ice"
+				"Negated" "0"
+				"condition" "130"
+				"OnFail" "!activator,$AddItemAttribute,damage bonus HIDDEN|0.7|0,0.1,-1"
+				"OnFail" "!activator,$AddItemAttribute,bullets per shot bonus|4|0,0.1,-1"
+				"OnFail" "!activator,$AddItemAttribute,spread penalty|2|0,0.1,-1"
+				
+				"OnPass" "!activator,$AddItemAttribute,damage bonus HIDDEN|0.7|0,0.1,-1"
+				"OnPass" "!activator,$AddItemAttribute,bullets per shot bonus|4|0,0.1,-1"
+				"OnPass" "!activator,$AddItemAttribute,spread penalty|2|0,0.1,-1"
+			}
+            logic_relay 
+            {
+				"targetname" "ice_checker"
+				"OnTrigger" "filter_has_ice,TestActivator,!activator,0,-1"
+            }
+        }
 	}
 	
 	
 	
 	//Vortex-es. Vortices?
+	//just kidding, now it's just one!
 	SpawnTemplate [$SIGSEGV]
 	{
 		Name "VortexSky"
 		Origin	"2020 3880 2200"
 	}
+	
+	SpawnTemplate "GetOffMe" [$SIGSEGV] //nav fix
 	
 	// SpawnTemplate [$SIGSEGV]
 	// {
@@ -877,8 +1059,48 @@ popuwashyon
 		"bleeding duration"				0
 		"dmg taken from fire increased"	1
 		"crit mod disabled"				1
+		"special item description" "Old stats removed. Can randomly crit now!"
 	}
 	
+	//Vita-saw: enable building healing!
+	//yes I picked up this stuff from Jurrell. Thanks, nerd :3
+    PlayerItemEquipSpawnTemplate
+	{
+		Name "vsaw_equipped"
+		ItemName "The Vita-saw"
+	}
+	ItemAttributes [$SIGSEGV]
+	{
+		ItemName "The Vita-saw"
+		"special item description" "When equipped: allows you to heal buildings for 15 hp/sec!"
+	}
+	
+	
+	//Arrow shotgun! Because it's just really cool to use 8) 
+	ItemAttributes [$SIGSEGV]
+	{
+		ItemName "The Huntsman"
+		"arrow mastery" 1
+		"projectile penetration" 1
+		"projectile penetration" -1 //Disallows buying pene. Does not break middle arrow.
+		"special item description" "Penetration is disabled to prevent arrows from breaking."
+	}
+	
+	//The Spy-cicle's niche is too niche for MvM, making it a stock knife...
+	//with a weird sapper interaction...
+	//So here's something cool for it.
+    PlayerItemEquipSpawnTemplate
+	{
+		Name "ice_equipped"
+		ItemName "The Spy-cicle"
+	}
+	ItemAttributes [$SIGSEGV]
+	{
+		ItemName "The Spy-cicle"
+		"cannot be upgraded" 1
+		"max health additive bonus" 25
+		"special item description" "When equipped: turns your revolver into a mini shotgun! +3 bullets per shot, -30% damage, double spread."
+	}
 	
 	// The funny blatantly overpowered things
 	
@@ -1409,6 +1631,10 @@ popuwashyon
 			Tag giant
 			AimAt Head [$SIGSEGV]
 			MaxVisionRange 750
+			AddCond [$SIGSEGV]
+			{
+				Index 36 //hype!
+			}
 			ItemAttributes
 			{
 				ItemName "The Manmelter"
@@ -2028,7 +2254,10 @@ popuwashyon
 			Tag giant
 			AimAt Head [$SIGSEGV]
 			MaxVisionRange 750
-			Tag giant
+			AddCond [$SIGSEGV]
+			{
+				Index 36 //hype!
+			}
 			ItemAttributes
 			{
 				ItemName "The Detonator"
@@ -3283,8 +3512,8 @@ popuwashyon
 				StartingPathTrackNode "tank_path_a"
 				OnBombDroppedOutput
 				{
-					Target boss_deploy_relay 					
-					Action Trigger                         		
+					Target boss_deploy_relay
+					Action Trigger
 				}
 			}
 		}
@@ -4179,7 +4408,7 @@ popuwashyon
 			Name "wave5ab"
 			Where spawnbot_invasion
 			WaitBetweenSpawns 0.5
-			TotalCount 48
+			TotalCount 60
 			MaxActive 12
 			SpawnCount 4
 			TotalCurrency 100
@@ -4591,6 +4820,11 @@ popuwashyon
 				Name "tank"
 				Speed 75
 				StartingPathTrackNode "tank_path_b"
+                OnBombDroppedOutput
+                {
+                    Target boss_deploy_relay
+                    Action Trigger
+                }
 			}
 		}
 		WaveSpawn
@@ -4722,7 +4956,7 @@ popuwashyon
 			WaitForAllSpawned "wave6b"
 			WaitBeforeStarting 5
 			TotalCount 1
-			TotalCurrency 80
+			TotalCurrency 90
 			Tank
 			{
 				Health 30000
@@ -4732,6 +4966,11 @@ popuwashyon
 				Speed 75
 				StartingPathTrackNode "tank_path_a"
 				SpawnTemplate Teleporter [$SIGSEGV]
+                OnBombDroppedOutput
+                {
+                    Target boss_deploy_relay
+                    Action Trigger
+                }
 			}
 		}
 		WaveSpawn
@@ -4787,7 +5026,7 @@ popuwashyon
 			TotalCount 10
 			MaxActive 4
 			SpawnCount 1
-			TotalCurrency 10
+			TotalCurrency 0
 			Support 1
 			TFBot
 			{
@@ -5164,24 +5403,20 @@ popuwashyon
 		// {
 			// Name "Support"
 			// WaitBeforeStarting 1
-			// Where spawnbot_invasion
-			// WaitBetweenSpawnsAfterDeath 15
+			// Where spawnbot
+			// WaitBetweenSpawnsAfterDeath 1
 			// TotalCount 8
-			// MaxActive 2
-			// SpawnCount 2
+			// MaxActive 1
+			// SpawnCount 1
 			// Squad
 			// {
 				// TFBot
 				// {
 					// Template T_TFBot_Giant_Pyro
-					// Attributes IgnoreEnemies
-					// Attributes IgnoreFlag
-					// BehaviorModifiers Push
+					// Tag giant
+					// Attributes SuppressFire
+					// Attributes DisableDodge
 					// Health 1000
-				// }
-				// TFBot
-				// {
-					// Template Bee_Giant_Medic_AoE
 				// }
 			// }
 		// }

--- a/scripts/population/mvm_shank_rc4_adv_moonlight_menace.pop
+++ b/scripts/population/mvm_shank_rc4_adv_moonlight_menace.pop
@@ -428,7 +428,7 @@ tomboy
 			{
 				Target "tip_explosion"
 				Action "$InheritOwner"
-                Param "!activator"
+        Param "!activator"
 				Delay 0.1
 			}
 
@@ -498,24 +498,18 @@ tomboy
         "TargetScale" "1"
       }
 
-      info_particle_system
+      env_entity_maker
       {
-        "targetname" "sticky_flicker"
-        "effect_name" "stickybomb_pulse_red"
-        "flag_as_weather" "0"
-        "start_active" "0"
-		
-		"OnUser1" "!self,Start,2,1,-1"
-        "OnUser1" "!self,Kill,2.7,3,-1"
-      }
-      logic_measure_movement 
-      {
-        "MeasureReference" "detonate_position"
-        "MeasureTarget" "detonate_position"
-        "MeasureType" "0"
-        "Target" "sticky_flicker"
-        "TargetReference" "detonate_position"
-        "TargetScale" "1"
+        "targetname" "sticky_flicker_maker"
+        "EntityTemplate" "Stickybomb_Flicker_Particle"
+        "PostSpawnDirection" "0 0 0"
+        "PostSpawnDirectionVariance" "0"
+        "PostSpawnInheritAngles" "0"
+        "PostSpawnSpeed" "0"
+        "spawnflags" "0"
+
+        "OnUser1" "!self,ForceSpawn,,1,-1"
+        "OnUser1" "!self,Kill,,2.1,-1"
       }
 
       ambient_generic
@@ -646,24 +640,18 @@ tomboy
         "TargetScale" "1"
       }
 
-      info_particle_system
+      env_entity_maker
       {
-        "targetname" "sticky_flicker"
-        "effect_name" "stickybomb_pulse_blue"
-        "flag_as_weather" "0"
-        "start_active" "0"
-		
-		"OnUser1" "!self,Start,2,1,-1"
-        "OnUser1" "!self,Kill,2.7,3,-1"
-      }
-	  logic_measure_movement 
-      {
-        "MeasureReference" "detonate_position"
-        "MeasureTarget" "detonate_position"
-        "MeasureType" "0"
-        "Target" "sticky_flicker"
-        "TargetReference" "detonate_position"
-        "TargetScale" "1"
+        "targetname" "sticky_flicker_maker"
+        "EntityTemplate" "Stickybomb_Flicker_Particle_Blue"
+        "PostSpawnDirection" "0 0 0"
+        "PostSpawnDirectionVariance" "0"
+        "PostSpawnInheritAngles" "0"
+        "PostSpawnSpeed" "0"
+        "spawnflags" "0"
+
+        "OnUser1" "!self,ForceSpawn,,1,-1"
+        "OnUser1" "!self,Kill,,2.1,-1"
       }
 
       ambient_generic
@@ -2941,7 +2929,7 @@ tomboy
         "min" "0"
         "max" "10"
 
-        "OnGetValue" "aoe_regen_increaser,$SetKey$case02,,0,-1"
+        "OnGetValue" "aoe_regen_increaser,$SetKey$case01,,0,-1"
         "OnGetValue" "aoe_regen_increaser,$Format,,0.1,-1"
         "OnUser1" "!self,Add,0.001,0,-1"
         "OnUser1" "!self,GetValue,,0.1,-1"
@@ -2963,7 +2951,6 @@ tomboy
       logic_case
       {
         "targetname" "aoe_regen_increaser"
-        //"case16" "OnStartTouch !activator:$DisplayTextCenter:ammo regen|%:%:-1"
         "case16" "OnStartTouch !activator:$AddPlayerAttribute:ammo regen|%:%:-1"
         "case01" "0"
         "case02" "0"
@@ -3776,7 +3763,7 @@ tomboy
   
         //"OutValue" "red_player,$DisplayTextCenter,,0,-1" 
         "OutValue" "Natascha_berserkpoints_apply,$SetKey$case01,,0,-1"
-        "OutValue" "Natascha_berserkpoints_apply,$Format,,0.001,-1"
+        "OutValue" "Natascha_berserkpoints_apply,$Format,,0,-1"
       }
 
       logic_case
@@ -3788,7 +3775,7 @@ tomboy
         //"ondefault" "red_player,$DisplayTextCenter,,0,-1" 
         "ondefault" "!activator,AddOutput,,0,-1"
         "ondefault" "!self,$SetKey$case01,0,0,-1"
-        //"ondefault" "!self,$Format,0,0,-1"
+        "ondefault" "!self,$Format,0,0,-1"
       }
 
       logic_case 
@@ -3827,7 +3814,7 @@ tomboy
 
       OnSpawnOutput
       {
-        Target "berserk_meter_formatter"
+        Target "beserk_meter_formatter"
         Action "$SetKey$case01"
         Param "0"
         Delay 0
@@ -3835,7 +3822,7 @@ tomboy
 
       OnSpawnOutput
       {
-        Target "berserk_meter_formatter"
+        Target "beserk_meter_formatter"
         Action "$Format"
         Param "0"
         Delay 0
@@ -3851,7 +3838,7 @@ tomboy
 
       filter_tf_condition
 			{
-				"targetname" "berserk_filter_is_taunting"
+				"targetname" "beserk_filter_is_taunting"
 				"Negated" "0"
 				"condition" "7"
 
@@ -3877,26 +3864,26 @@ tomboy
 
         "InitialValue" "0"
 
-        "OnFalse" "berserk_start_checker,Disable,,0,-1"
-        "OnTrue" "berserk_start_checker,Enable,,0,-1"
-        "OnTrue" "berserk_start_checker,Trigger,,0.1,-1"
+        "OnFalse" "beserk_start_checker,Disable,,0,-1"
+        "OnTrue" "beserk_start_checker,Enable,,0,-1"
+        "OnTrue" "beserk_start_checker,Trigger,,0.1,-1"
         //"OnTrue" "berserk_ready_text,Display,,0,-1"
         "OnTrue" "!activator,$DisplayTextCenter,Berserk is ready. Taunt to activate,0,-1" 
       }
 
       logic_relay 
       {
-        "targetname" "berserk_start_checker"
+        "targetname" "beserk_start_checker"
         "spawnflags" "2"
         "StartDisabled" "1"
 
         "OnTrigger" "!self,Trigger,,0.1,-1"  
-        "OnTrigger" "berserk_filter_is_taunting,TestActivator,!activator,0,-1" 
+        "OnTrigger" "beserk_filter_is_taunting,TestActivator,!activator,0,-1" 
       }
 
       logic_case
       {
-        "targetname" "berserk_meter_formatter"
+        "targetname" "beserk_meter_formatter"
         "case16" "message Berserk %/2500" //damage requirement (visual only)
         "case01" "<ERROR>"
 
@@ -3914,8 +3901,8 @@ tomboy
         
         //"OnHitMax" "player,$DisplayTextCenter,full,0,-1" 
         "OnHitMax" "is_berserk_ready,SetValueTest,1,0,-1"
-        "OnGetValue" "berserk_meter_formatter,$SetKey$case01,,0,-1"
-        "OnGetValue" "berserk_meter_formatter,$Format,,0.001,-1"
+        "OnGetValue" "beserk_meter_formatter,$SetKey$case01,,0,-1"
+        "OnGetValue" "beserk_meter_formatter,$Format,,0,-1"
       }
 
       game_text
@@ -4260,7 +4247,7 @@ tomboy
         "max" "0"
         
         "OnGetValue" "amputator_id_assigner,$SetKey$case01,,0,-1"
-        "OnGetValue" "amputator_id_assigner,$Format,,0.001,-1"
+        "OnGetValue" "amputator_id_assigner,$Format,,0,-1"
         "OnUser1" "!self,GetValue,,0,-1"  
       }
 
@@ -4498,7 +4485,7 @@ tomboy
         "spawnflags" "1"
         "StartDisabled" "1"
         "filtername" "filter_amputator_teleport_main"
-        "target" "medic_position"
+        //"target" "medic_position"
 
         "OnStartTouch" "!activator,$PlaySoundToSelf,mvm/mvm_revive.wav,0,-1"
         "OnStartTouch" "!activator,$AddCond,52,0,-1"
@@ -4830,7 +4817,7 @@ tomboy
   {
     ItemName "Natascha"
     //"minigun spinup time increased" 1
-    "special item description" "Deal damage to build Berserk. Taunt to activate Berserk and gain health on hit for 10 seconds"
+    "special item description" "Deal damage to build Beserk. Taunt to activate Berserk and gain health on hit for 10 seconds"
   }
 
   ItemAttributes
@@ -6327,7 +6314,7 @@ tomboy
       Line "{FFD700}The Degreaser {FFFFFF}- +75% damage bonus on secondary weapon,  +125% damage bonus on melee weapon (+150% damage bonus with {FFD700}The Axtinguisher{FFFFFF}). 90% damage penalty on primary"
       Line "{FFD700}The Ullapool Caber {FFFFFF}- Turns you into a Sentry Buster with increased speed, 800 health and reduced push force. Taunt to detonate. Detonation reverts you back to a normal Demoman with temporal uber and speed boost"
       //Line "{FFD700}The Huo-Long Heater {FFFFFF}- Fires a flare projectile every 6 seconds while shooting"
-      Line "{FFD700}The Natascha {FFFFFF}- Deal damage to build Berserk. Taunt to activate Berserk and gain health on hit for 10 seconds"
+      Line "{FFD700}The Natascha {FFFFFF}- Deal damage to build Beserk. Taunt to activate Berserk and gain health on hit for 10 seconds"
       Line "{FFD700}The Gunslinger {FFFFFF}- 125% damage bonus on all weapons while equipped (90% damage bonus with {FFD700}The Widowmaker{FFFFFF} equipped)"
       Line "{FFD700}The Amputator {FFFFFF}- On taunt: revives all dead teammates and teleport them to your location with temporary uber and speed boost. Ability has a 40 seconds cooldown between use (cooldown is shared across all medics)"
       Line "{FFD700}All bows {FFFFFF}- Fire explosive arrows that stick to enemies and surfaces, detonate after 3 seconds"


### PR DESCRIPTION
- Condemned - Trespasser
	- Fixed heavy class limit not working
	- +75% gesture speed increase to heavy lunchboxes
	
- Creepside - Dismal Devilry
	- General: 
		- Added "health from healers reduced" 0.1 on red bots that did not previously have the attribute.
	- Wave 2: 
		- Reduced gray pyro speed by 25% and reduced skill to normal.
	- Wave 3: 
		- Increased cooldown between spell casts on the spell tank.
	- Wave 6: 
		- Decreased the amount of resistance meds on each giant heavy squad by one.
		
- Nightsky - Nightsky Nightmare
	- General: 
	- Added changes to Vita-saw, Huntsman, Spy-cicle;
		- Vita-saw: on equip, allows you to heal buildings (15 hp/sec)
		- Huntsman: Arrow Mastery level 1, penetration disabled.
		- Spy-cicle: Not upgradeable, +25 health, Any equipped revolver gains 4x bullets, 0.7x damage, 2x spread.
	- Blacklisted canteens

	- Wave 2:
		- Added Hype condition to the Giant Homing Flare Rains

	- Wave 5:
		- Added Hype condition to the Giant Homing Flare Rains
		- Added 12 Killer Bee Scouts to the first subwave

	- Wave 6:
		- Altered cash drops
		- Fixed both tanks not deploying the bomb.
		
- Shank - Moonlight Menace
	- Fixed/altered rebalances